### PR TITLE
Adds Chainstack to publicly available tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 | Underdog API | Seamlessly integrate dynamic NFTs into your product | API, dApps | <https://underdogprotocol.com/> |
 | Concise Labs GraphQL API | GraphQL API for Solana program data | API, dApps | <https://api-docs.conciselabs.io/docs/get-started/GraphQL%20API> |
 | Xray | Human-readable Solana transaction explorer powered by Helius | Explorer, Programs, dApps | <https://github.com/helius-labs/xray> |
+| Chainstack | Suite of Web3 (including Solana) infrastructure services | Nodes, API, Data | <https://chainstack.com/> |
 
 ## In Development
 


### PR DESCRIPTION
Adds Chainstack- 

A platform that connects developers with Web3 infrastructure through things like high-performance & customizable RPC nodes, subgraphs, APIs, etc. Chainstack has full Solana support.