### PR TITLE
add `anchor-errors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@
 | SolStromm | CI/CD for Solana programs & dApps | YAML, Programs, dApps, CI/CD | <https://github.com/Adithya2907/solana-devops/>  |
 | EventSnap | Leveraging on-chain events using an infrastructure-less approach | Rust, Programs, Logging | <https://github.com/event-snap/event-snap>  |
 | Solex | VSCode extension to learn Solana development with bite-sized exercises | Rust, Programs, Learn | Not yet public |
+| anchor-errors | A TUI which acts as an explorer for errors of native programs (and other popular solana programs) | <https://github.com/0xmukesh/anchor-errors> | 


### PR DESCRIPTION
`anchor-errors` is a TUI which acts as an explorer for errors of native solana programs (and other popular programs).
`anchor-errors` isn't yet published on pkg.go.dev. It'd be published after polishing the UI and adding few more program supports.

demo: https://asciinema.org/a/JPM16ASqKzl2iNIwV0yAs4Chu