### PR TITLE
Add SMWA Injection Tool to Publicly Available tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 | Elusiv SDK | SDK for adding zk-privacy to dApps | TypeScript, dApps, Privacy | <https://github.com/elusiv-privacy/elusiv-sdk> |
 | Metaboss | The Metaplex NFT 'Swiss Army Knife' tool | Rust, CLI, NFTs | <https://github.com/samuelvanderwaal/metaboss> |
 | Nonci | API and SDK tool for queuing and executing transactions asynchronously using durable nonces to handle crazy bursts! | Typescript, SDK, API | <https://github.com/nonci-xyz> |
+| SMWA Injection Tool | Injects Mobile Wallet Adapter into any Android Chrome page — enables Solana dApps to load wallet pickers on non-Saga Android devices | TypeScript, dApps, Mobile | https://github.com/plinkdev1/SMWA-InjectionTool |
 
 ## In Development
 


### PR DESCRIPTION
SMWA Injection Tool is an open source MIT-licensed toolkit that injects Mobile Wallet Adapter into any Android Chrome page — enabling Solana dApps to load wallet pickers (Phantom, Backpack, Solflare) on non-Saga Android devices via Chrome DevTools Protocol or Chrome Extension.

- v1.0.0 live and tested
- Confirmed working on Jupiter, Orca, Raydium, Magic Eden and Drift
- MIT licensed
- Actively maintained

Repo: https://github.com/plinkdev1/SMWA-InjectionTool