### PR TITLE
feat: add TWZRD Agent Intel — Solana x402 agent trust scoring MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 | Elusiv SDK | SDK for adding zk-privacy to dApps | TypeScript, dApps, Privacy | <https://github.com/elusiv-privacy/elusiv-sdk> |
 | Metaboss | The Metaplex NFT 'Swiss Army Knife' tool | Rust, CLI, NFTs | <https://github.com/samuelvanderwaal/metaboss> |
 | Nonci | API and SDK tool for queuing and executing transactions asynchronously using durable nonces to handle crazy bursts! | Typescript, SDK, API | <https://github.com/nonci-xyz> |
+| TWZRD Agent Intel | Solana-native trust-scoring MCP server for x402 agents — free on-chain preflight checks and paid signed trust receipts via USDC micropayment (<1s settlement) | MCP, API, AI Agents, x402 | <https://intel.twzrd.xyz> |
 
 ## In Development
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Publicly Available tools list.

**TWZRD Agent Intel** is a Solana-native trust-scoring MCP server for AI agents using the x402 micropayment protocol:
- Free on-chain preflight checks (agent resolution, trust scoring)
- Paid signed trust receipts via USDC micropayment via x402 (<1s settlement on Solana)
- MCP server URL: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP)
- Tools: `resolve_agent`, `score_agent`, `get_trust_receipt`, `verify_trust_receipt`
- GitHub: 

Tags: `MCP, API, AI Agents, x402`